### PR TITLE
Exclude uitests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
-    groups:
-      selenium-dependencies:
-        patterns: 
-          - "Selenium*"
-
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - uses: nanasess/setup-chromedriver@v2
     - name: Test
-      run: dotnet test ~IntelliTect.TestTools.Selenate.Tests.dll --no-build --configuration Release --verbosity normal
+      run: dotnet test --filter FullyQualifiedName!~Selenate.Examples --no-build --configuration Release --verbosity normal
 
   automerge:
     needs: [build-and-test]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - uses: nanasess/setup-chromedriver@v2
     - name: Test
-      run: dotnet test ~/IntelliTect.TestTools.Selenate.Tests/IntelliTect.TestTools.Selenate.Tests.csproj --no-build --configuration Release --verbosity normal
+      run: dotnet test ~IntelliTect.TestTools.Selenate.Tests.csproj --no-build --configuration Release --verbosity normal
 
   automerge:
     needs: [build-and-test]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - uses: nanasess/setup-chromedriver@v2
     - name: Test
-      run: dotnet test ~IntelliTect.TestTools.Selenate.Tests.csproj --no-build --configuration Release --verbosity normal
+      run: dotnet test ~IntelliTect.TestTools.Selenate.Tests.dll --no-build --configuration Release --verbosity normal
 
   automerge:
     needs: [build-and-test]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet build -p:ContinuousIntegrationBuild=True --no-restore --configuration Release
     - uses: nanasess/setup-chromedriver@v2
     - name: Test
-      run: dotnet test --no-build --configuration Release --verbosity normal
+      run: dotnet test ~/IntelliTect.TestTools.Selenate.Tests/IntelliTect.TestTools.Selenate.Tests.csproj --no-build --configuration Release --verbosity normal
 
   automerge:
     needs: [build-and-test]


### PR DESCRIPTION
## Description

- Exclude UI tests from running. For some reason, they're taking a really long time. They're also mainly for examples, so not super valuable. I'll file a ticket to figure out what's going on with them.
- Don't automatically bump Selenium. In some cases, we don't necessarily want to be on latest for compatibility reasons.

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
