### PR TITLE
Fix fetching many elemhandlers

### DIFF
--- a/IntelliTect.TestTools.Selenate.Tests/GetElementHandlersTests.cs
+++ b/IntelliTect.TestTools.Selenate.Tests/GetElementHandlersTests.cs
@@ -66,7 +66,7 @@ public class GetElementHandlersTests
     public void GetElementHandlersWorksWithAllSelectorTypes(string selectorType)
     {
         const string cssIndex = ":nth-of-type";
-        List<By> convertedBys = new();
+        List<By> convertedBys = new(2);
 
         for (int i = 1; i < 3; i++)
         {
@@ -121,7 +121,6 @@ public class GetElementHandlersTests
     [InlineData("xpath", "//div[@id='test']{index}/div", "//div[@id='test'][{index}]/div")]
     public void GetElementHandlersWorksWithAllSelectorTypesTest(string selectorType, string selectorCriteria, string expectedResult)
     {
-        //const string cssIndex = ":nth-of-type";
         List<By> convertedBys = new(2);
 
         for (int i = 1; i < 3; i++)

--- a/IntelliTect.TestTools.Selenate/ElementsHandler.cs
+++ b/IntelliTect.TestTools.Selenate/ElementsHandler.cs
@@ -112,6 +112,8 @@ namespace IntelliTect.TestTools.Selenate
         /// Respects any timeout set for this ElementsHandler. <br /> <br />
         /// NOTE: By.Name locators have not yet been verified to work. Please file an issue if one is encountered: https://github.com/IntelliTect/TestTools.Selenate/issues
         /// </summary>
+        /// <param name="byOverride">Used to override the locator only for this operation. This is primarily used when your regular locator <br />
+        /// is needed for other operations, but you must specify where the indexing call needs to go for this specific operation.</param>
         /// <returns>The enumerable of ElementHandlers that exist at the time of invocation.</returns>
         public IEnumerable<ElementHandler> GetElementHandlers(By? byOverride = null)
         {


### PR DESCRIPTION
## Description

Update ElementsHandler.GetElementHandlers to have an optional By parameter. If one is supplied, it will be used instead of the regular Locator. This is to facilitate cases where the locator used may work fine for most operations, but the index in GetElementHandlers can't be at the end to work properly.

Fixes #115 

### Ensure that your pull request has followed all the steps below:
- [x] Code compilation
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
